### PR TITLE
fix: downgrade scipy version from 1.14.0 to 1.13.1 in requirements

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -5,7 +5,7 @@ safetensors==0.4.3
 accelerate==0.32.1
 pyyaml==6.0.1
 pillow==10.4.0
-scipy==1.14.0
+scipy==1.13.1
 tqdm==4.66.4
 psutil==6.0.0
 pytorch_lightning==2.3.3


### PR DESCRIPTION
## Description

Referenced version 1.14.0 simply does not exist.
